### PR TITLE
Exclude Math formulas from vale checks

### DIFF
--- a/build_tools/vale/.vale.ini
+++ b/build_tools/vale/.vale.ini
@@ -22,6 +22,7 @@ mdx = md
 # List of styles to load
 BasedOnStyles = Vale, proselint, write-good, Microsoft, Consensys
 # Style.Rule = {YES, NO} to enable or disable a specific rule
+TokenIgnores = (\$+[^$]+\$+)
 
 Microsoft.Contractions = warning
 Microsoft.GeneralURL = NO


### PR DESCRIPTION
Use [Vale ignore](https://docs.errata.ai/vale-server/concepts/scoping#non-standard-markup) to prevent math formulas between `$...$` and `$$...$$` to be checked.

this PR should fix Math issues in https://github.com/ConsenSys/doc.gnark/pull/3

Submodule update will be required once merged