### PR TITLE
remove diacritical "doppelgänger"

### DIFF
--- a/build_tools/vale/vale_styles/proselint/Diacritical.yml
+++ b/build_tools/vale/vale_styles/proselint/Diacritical.yml
@@ -67,7 +67,6 @@ swap:
   acai: açaí
 
   # German loanwords
-  doppelganger: doppelgänger
   Fuhrer: Führer
   Gewurztraminer: Gewürztraminer
   vis-a-vis: vis-à-vis


### PR DESCRIPTION
Remove diacritical error on the German term "doppelgänger." "Doppelganger" is an accepted variant of this term, and is the name used in the Teku feature.